### PR TITLE
🐛 瞬き補完時にスコープが\1のままになることがあったのを修正

### DIFF
--- a/ghost/master/src/events/common.rs
+++ b/ghost/master/src/events/common.rs
@@ -379,7 +379,7 @@ pub fn on_smooth_blink(req: &Request) -> Response {
   let delay = format!("\\_w[{}]", DELAY);
   let animation = cuts
     .iter()
-    .map(|s| format!("\\s[{}]{}", s, complete_shadow(is_complete)))
+    .map(|s| format!("\\0\\s[{}]{}", s, complete_shadow(is_complete)))
     .collect::<Vec<String>>()
     .join(delay.as_str());
 


### PR DESCRIPTION
ひと息つくコマンドの直後などに発生していた