### PR TITLE
没入度の扱いを変更し、書斎をハイネの内面世界として描写するように

### DIFF
--- a/ghost/master/src/error.rs
+++ b/ghost/master/src/error.rs
@@ -11,6 +11,7 @@ pub enum ShioriError {
   TranslaterNotReadyError,
   TalkNotFound,
   ParseRequestError,
+  NotSetScopeError(String),
 }
 
 impl fmt::Display for ShioriError {
@@ -38,6 +39,11 @@ impl fmt::Display for ShioriError {
       ShioriError::ParseRequestError => write!(
         f,
         "[ParseRequestError]SHIORIリクエストのパースに失敗しました"
+      ),
+      ShioriError::NotSetScopeError(v) => write!(
+        f,
+        "[NotSetScopeError]次のスクリプトの頭にスコープ指定がありません: {}",
+        v
       ),
     }
   }

--- a/ghost/master/src/events.rs
+++ b/ghost/master/src/events.rs
@@ -108,7 +108,6 @@ fn get_event(id: &str) -> Option<EventHandler> {
     "OnSurfaceChange" => Some(EventHandler::MayFailure(on_surface_change)),
     "OnSmoothBlink" => Some(EventHandler::MayFailure(on_smooth_blink)),
     "OnMenuExec" => Some(EventHandler::AlwaysSuccess(on_menu_exec)),
-    "OnBreakTime" => Some(EventHandler::MayFailure(on_break_time)),
     "OnImmersiveRateReduced" => Some(EventHandler::MayFailure(on_immersive_rate_reduced)),
     "OnTalkIntervalChanged" => Some(EventHandler::MayFailure(on_talk_interval_changed)),
     "OnMouseClickEx" => Some(EventHandler::MayFailure(on_mouse_click_ex)),

--- a/ghost/master/src/events/aitalk.rs
+++ b/ghost/master/src/events/aitalk.rs
@@ -197,6 +197,31 @@ pub fn on_anchor_select_ex(req: &Request) -> Result<Response, ShioriError> {
   }
 }
 
+pub fn reset_immersion() -> Option<Result<Response, ShioriError>> {
+  let vars = get_global_vars();
+  let immersive_degrees = vars.volatility.immersive_degrees();
+  if immersive_degrees < IMMERSIVE_RATE_MAX / 2 {
+    None
+  } else {
+    vars.volatility.set_immersive_degrees(0);
+    let parts = vec![vec!["hr1111705……。\
+        \\1ハイネ……hr1111101\\1ハイネ！\
+        h1111204ええ、ええ。えっと……何だったかしら？\
+        \\1\\n\\n(没入度がリセットされました)"
+      .to_string()]];
+    let dialogs = all_combo(&parts);
+    let index = if let Some(v) = choose_one(&dialogs, true) {
+      v
+    } else {
+      return Some(Err(ShioriError::TalkNotFound));
+    };
+    Some(new_response_with_value_with_translate(
+      dialogs[index].to_owned(),
+      TranslateOption::with_shadow_completion(),
+    ))
+  }
+}
+
 #[cfg(test)]
 mod test {
   use super::*;

--- a/ghost/master/src/events/common.rs
+++ b/ghost/master/src/events/common.rs
@@ -1,7 +1,7 @@
 use crate::check_error;
 use crate::error::ShioriError;
 use crate::events::aitalk::IMMERSIVE_RATE_MAX;
-use crate::events::talk::{TalkType, TalkingPlace};
+use crate::events::talk::TalkType;
 use crate::events::translate::on_translate;
 use crate::roulette::RouletteCell;
 use crate::variables::get_global_vars;
@@ -229,11 +229,7 @@ pub fn render_shadow(is_complete: bool) -> String {
   const MAX_Y: i32 = -200;
   let vars = get_global_vars();
   if is_complete {
-    let degree = if vars.volatility.talking_place() == TalkingPlace::Library {
-      100 - vars.volatility.immersive_degrees()
-    } else {
-      vars.volatility.immersive_degrees()
-    };
+    let degree = vars.volatility.immersive_degrees();
     format!(
       "\\0\\![bind,ex,没入度用,1]\\![anim,offset,800100,0,{}]",
       ((MAX_Y - DEFAULT_Y) as f32 * (degree as f32 / (IMMERSIVE_RATE_MAX as f32))) as i32

--- a/ghost/master/src/events/common.rs
+++ b/ghost/master/src/events/common.rs
@@ -472,6 +472,21 @@ pub fn render_achievement_message(talk_type: TalkType) -> String {
   )
 }
 
+pub fn add_immsersive_degree(degree: u32) {
+  let vars = get_global_vars();
+  let new_degree = std::cmp::min(
+    vars.volatility.immersive_degrees() + degree,
+    IMMERSIVE_RATE_MAX,
+  );
+  vars.volatility.set_immersive_degrees(new_degree);
+}
+
+pub fn sub_immsersive_degree(degree: u32) {
+  let vars = get_global_vars();
+  let new_degree = vars.volatility.immersive_degrees().saturating_sub(degree);
+  vars.volatility.set_immersive_degrees(new_degree);
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/ghost/master/src/events/common.rs
+++ b/ghost/master/src/events/common.rs
@@ -226,7 +226,7 @@ pub fn user_talk(dialog: &str, text: &str, text_first: bool) -> String {
 
 pub fn render_shadow(is_complete: bool) -> String {
   const DEFAULT_Y: i32 = -700;
-  const MAX_Y: i32 = -100;
+  const MAX_Y: i32 = -200;
   let vars = get_global_vars();
   if is_complete {
     let degree = if vars.volatility.talking_place() == TalkingPlace::Library {

--- a/ghost/master/src/events/menu.rs
+++ b/ghost/master/src/events/menu.rs
@@ -5,6 +5,7 @@ use crate::events::first_boot::FIRST_RANDOMTALKS;
 use crate::events::input::InputId;
 use crate::events::talk::randomtalk::random_talks;
 use crate::events::tooltip::show_tooltip;
+use crate::events::TalkingPlace;
 use crate::variables::{get_global_vars, EventFlag};
 use shiorust::message::{Request, Response};
 
@@ -73,12 +74,20 @@ pub fn on_menu_exec(_req: &Request) -> Response {
         ",
         talk_interval_selector,
         close_button,
-        show_bar(
-          100,
-          vars.volatility.immersive_degrees(),
-          "没入度",
-          "WhatIsImersiveDegree",
-        ),
+        if vars.volatility.talking_place() == TalkingPlace::Library {
+          show_bar_with_simple_label(
+            100,
+            vars.volatility.immersive_degrees(),
+            "ハイネは応えない。",
+          )
+        } else {
+          show_bar_with_caption(
+            100,
+            vars.volatility.immersive_degrees(),
+            "没入度",
+            "WhatIsImersiveDegree",
+          )
+        },
       )
     },
   );
@@ -106,7 +115,7 @@ fn make_bar_chips(length: u32) -> Vec<String> {
   v
 }
 
-fn show_bar(max: u32, current: u32, label: &str, tooltip_id: &str) -> String {
+fn show_bar_with_caption(max: u32, current: u32, label: &str, tooltip_id: &str) -> String {
   const SPEED: u32 = 10; // 何文字分の表示時間でバーを描画するか
   const BAR_WIDTH: u32 = 16; // バーの長さを何文字分で描画するか
   const BAR_HEIGHT: u32 = 10;
@@ -126,6 +135,30 @@ fn show_bar(max: u32, current: u32, label: &str, tooltip_id: &str) -> String {
     label,
     rate,
     show_tooltip(tooltip_id),
+    BAR_HEIGHT,
+    make_bar_chips(bar_width).join("\\_l[@-0.5em,]"),
+    BAR_HEIGHT,
+    make_bar_chips(bar_width * rate / 100).join(&format!("\\_w[{}]\\_l[@-0.5em,]", bar_chip_wait)),
+  )
+}
+
+fn show_bar_with_simple_label(max: u32, current: u32, label: &str) -> String {
+  const SPEED: u32 = 10; // 何文字分の表示時間でバーを描画するか
+  const BAR_WIDTH: u32 = 16; // バーの長さを何文字分で描画するか
+  const BAR_HEIGHT: u32 = 10;
+  let rate = ((current * 100) as f32 / max as f32) as u32;
+  let bar_width = BAR_WIDTH * 2; // 重ねながら描画するので2倍
+  let bar_chip_wait = (50.0 * ((SPEED as f32) / (BAR_WIDTH as f32))) as u32; // 1文字分の表示時間
+
+  format!(
+    "\
+    \\f[height,{}]\\_l[{}em,]\\f[height,default]\\f[height,-1]\\![quicksection,true]{}\
+    \\f[height,{}]\\_l[0,@3]\\f[color,80,80,80]{}\
+    \\f[height,{}]\\_l[0,]\\f[color,120,0,0]{}\
+    ",
+    BAR_HEIGHT,
+    BAR_WIDTH + 1,
+    label,
     BAR_HEIGHT,
     make_bar_chips(bar_width).join("\\_l[@-0.5em,]"),
     BAR_HEIGHT,

--- a/ghost/master/src/events/menu.rs
+++ b/ghost/master/src/events/menu.rs
@@ -62,7 +62,6 @@ pub fn on_menu_exec(_req: &Request) -> Response {
         \\_l[0,1.5em]\
         \\![*]\\q[なにか話して,OnAiTalk]\\n\
         \\![*]\\q[話しかける,OnTalk]\\n\
-        {}\
         \\![*]\\q[トーク統計,OnCheckTalkCollection]\
         \\_l[0,@1.75em]\
         \\![*]\\q[手紙を書く,OnWebClapOpen]\
@@ -72,11 +71,6 @@ pub fn on_menu_exec(_req: &Request) -> Response {
         {}\
         \\_l[0,0]{}\
         ",
-        if vars.flags().check(&EventFlag::ImmersionUnlock) {
-          "\\![*]\\q[ひと息つく,OnBreakTime]\\n".to_string()
-        } else {
-          "".to_string()
-        },
         talk_interval_selector,
         close_button,
         show_bar(
@@ -137,19 +131,6 @@ fn show_bar(max: u32, current: u32, label: &str, tooltip_id: &str) -> String {
     BAR_HEIGHT,
     make_bar_chips(bar_width * rate / 100).join(&format!("\\_w[{}]\\_l[@-0.5em,]", bar_chip_wait)),
   )
-}
-
-pub fn on_break_time(_req: &Request) -> Result<Response, ShioriError> {
-  let m = "\
-      h1111101\\1……少し話に集中しすぎていたようだ。\\n\
-      h1111204\\1カップを傾け、一息つく。\\n\
-      h1113705\\1ハイネはこちらの意図を察して、同じように一口飲んだ。\\n\
-      \\n\
-      \\![embed,OnImmersiveRateReduced]\
-      "
-  .to_string();
-
-  new_response_with_value_with_translate(m, TranslateOption::with_shadow_completion())
 }
 
 pub fn on_immersive_rate_reduced(_req: &Request) -> Result<Response, ShioriError> {

--- a/ghost/master/src/events/menu.rs
+++ b/ghost/master/src/events/menu.rs
@@ -133,15 +133,27 @@ fn show_bar(max: u32, current: u32, label: &str, tooltip_id: &str) -> String {
   )
 }
 
-pub fn on_immersive_rate_reduced(_req: &Request) -> Result<Response, ShioriError> {
+pub fn on_immersive_rate_reduced(req: &Request) -> Result<Response, ShioriError> {
   // 没入度を下げる
+  let refs = get_references(req);
+  let degree = if let Some(r) = refs.first() {
+    r.parse::<u32>().unwrap_or(0)
+  } else {
+    0
+  };
+  let post_dialog = if let Some(r) = refs.get(1) {
+    r.to_string()
+  } else {
+    "".to_string()
+  };
   let vars = get_global_vars();
-  vars.volatility.set_immersive_degrees(0);
+  vars.volatility.set_immersive_degrees(degree);
 
-  let m = "\
-  \\Ch1111210\\1(没入度が0になった)\\x\\![raise,OnMenuExec]\
-  "
-  .to_string();
+  let m = format!(
+    "\\C\\0{}\\1(没入度が0になった){}",
+    render_shadow(true),
+    post_dialog
+  );
 
   new_response_with_value_with_translate(m, TranslateOption::with_shadow_completion())
 }

--- a/ghost/master/src/events/mouse.rs
+++ b/ghost/master/src/events/mouse.rs
@@ -155,8 +155,13 @@ pub fn mouse_dialogs(req: &Request, info: String) -> Result<Response, ShioriErro
     .unwrap_or_else(|| Ok(new_response_nocontent()))
 }
 
-fn zero_head_nade(_req: &Request, count: u32) -> Result<Response, ShioriError> {
+fn zero_head_nade(req: &Request, count: u32) -> Option<Result<Response, ShioriError>> {
   let vars = get_global_vars();
+
+  if vars.volatility.talking_place() == TalkingPlace::Library {
+    return Some(on_ai_talk(req));
+  }
+
   let results = if vars.volatility.aroused() {
     DIALOG_TOUCH_WHILE_HITTING.clone()
   } else {
@@ -167,11 +172,16 @@ fn zero_head_nade(_req: &Request, count: u32) -> Result<Response, ShioriError> {
     ]];
     phased_talks(count, dialogs).0
   };
-  common_choice_process(results)
+  Some(common_choice_process(results))
 }
 
-fn zero_face_nade(_req: &Request, count: u32) -> Result<Response, ShioriError> {
+fn zero_face_nade(req: &Request, count: u32) -> Option<Result<Response, ShioriError>> {
   let vars = get_global_vars();
+
+  if vars.volatility.talking_place() == TalkingPlace::Library {
+    return Some(on_ai_talk(req));
+  }
+
   let results = if vars.volatility.aroused() {
     DIALOG_TOUCH_WHILE_HITTING.clone()
   } else {
@@ -182,11 +192,16 @@ fn zero_face_nade(_req: &Request, count: u32) -> Result<Response, ShioriError> {
     ]];
     phased_talks(count, dialogs).0
   };
-  common_choice_process(results)
+  Some(common_choice_process(results))
 }
 
-fn zero_hand_nade(_req: &Request, count: u32) -> Result<Response, ShioriError> {
+fn zero_hand_nade(req: &Request, count: u32) -> Option<Result<Response, ShioriError>> {
   let vars = get_global_vars();
+
+  if vars.volatility.talking_place() == TalkingPlace::Library {
+    return Some(on_ai_talk(req));
+  }
+
   let results = if vars.volatility.aroused() {
     DIALOG_TOUCH_WHILE_HITTING.clone()
   } else {
@@ -209,11 +224,16 @@ fn zero_hand_nade(_req: &Request, count: u32) -> Result<Response, ShioriError> {
     ]];
     phased_talks(count, dialogs).0
   };
-  common_choice_process(results)
+  Some(common_choice_process(results))
 }
 
-fn zero_skirt_up(_req: &Request, _count: u32) -> Result<Response, ShioriError> {
+fn zero_skirt_up(_req: &Request, _count: u32) -> Option<Result<Response, ShioriError>> {
   let vars = get_global_vars();
+
+  if vars.volatility.talking_place() == TalkingPlace::Library {
+    return None;
+  }
+
   let results = if vars.volatility.aroused() {
     DIALOG_SEXIAL_WHILE_HITTING.clone()
   } else {
@@ -231,10 +251,10 @@ fn zero_skirt_up(_req: &Request, _count: u32) -> Result<Response, ShioriError> {
     }
     all_combo(&conbo_parts)
   };
-  common_choice_process(results)
+  Some(common_choice_process(results))
 }
 
-fn zero_shoulder_down(_req: &Request, count: u32) -> Result<Response, ShioriError> {
+fn zero_shoulder_down(_req: &Request, count: u32) -> Option<Result<Response, ShioriError>> {
   let dialogs = vec![
     vec!["\
       h1141601φ！\\_w[250]h1000000\\_w[1200]\\n\
@@ -254,11 +274,16 @@ fn zero_shoulder_down(_req: &Request, count: u32) -> Result<Response, ShioriErro
       .to_string(),
     ],
   ];
-  common_choice_process(phased_talks(count, dialogs).0)
+  Some(common_choice_process(phased_talks(count, dialogs).0))
 }
 
-fn zero_bust_touch(_req: &Request, count: u32) -> Result<Response, ShioriError> {
+fn zero_bust_touch(req: &Request, count: u32) -> Option<Result<Response, ShioriError>> {
   let vars = get_global_vars();
+
+  if vars.volatility.talking_place() == TalkingPlace::Library {
+    return Some(on_ai_talk(req));
+  }
+
   let results = if vars.volatility.aroused() {
     DIALOG_TOUCH_WHILE_HITTING.clone()
   } else {
@@ -295,7 +320,7 @@ fn zero_bust_touch(_req: &Request, count: u32) -> Result<Response, ShioriError> 
     }
     zero_bust_touch
   };
-  common_choice_process(results)
+  Some(common_choice_process(results))
 }
 
 pub fn on_head_hit_cancel(_req: &Request) -> Result<Response, ShioriError> {
@@ -328,8 +353,13 @@ pub fn on_head_hit(_req: &Request) -> Result<Response, ShioriError> {
   new_response_with_value_with_translate(m, TranslateOption::simple_translate())
 }
 
-pub fn head_hit_dialog(_req: &Request, count: u32) -> Result<Response, ShioriError> {
+pub fn head_hit_dialog(req: &Request, count: u32) -> Option<Result<Response, ShioriError>> {
   let vars = get_global_vars();
+
+  if vars.volatility.talking_place() == TalkingPlace::Library {
+    return Some(on_ai_talk(req));
+  }
+
   let is_aroused = vars.volatility.aroused();
   to_aroused();
   if !vars.flags().check(&EventFlag::FirstHitTalkStart) {
@@ -338,13 +368,13 @@ pub fn head_hit_dialog(_req: &Request, count: u32) -> Result<Response, ShioriErr
     \\s[1111101]\\![*]\\q[突き飛ばす,OnHeadHit]\\n\\![*]\\q[やめておく,OnHeadHitCancel]\
     "
     .to_string()];
-    common_choice_process(dialogs)
+    Some(common_choice_process(dialogs))
   } else if !is_aroused {
     get_touch_info!("0headdoubleclick").reset(); // 初回はカウントしない
     let dialogs = vec![
       "h1000000痛っ……\\n\\0\\![bind,ex,流血,1]h1311204あら、その気になってくれた？".to_string(),
     ];
-    common_choice_process(dialogs)
+    Some(common_choice_process(dialogs))
   } else {
     // 各段階ごとのセリフ
     let suffixes_list = vec![
@@ -387,7 +417,7 @@ pub fn head_hit_dialog(_req: &Request, count: u32) -> Result<Response, ShioriErr
     if is_last {
       vars.volatility.set_aroused(false);
       get_touch_info!("0headdoubleclick").reset();
-      return common_choice_process(suffixes);
+      return Some(common_choice_process(suffixes));
     }
 
     let prefixes = [
@@ -399,7 +429,7 @@ pub fn head_hit_dialog(_req: &Request, count: u32) -> Result<Response, ShioriErr
     for j in 0..suffixes.len() {
       result.push(format!("{}{}", prefixes[j % prefixes.len()], suffixes[j]));
     }
-    common_choice_process(result)
+    Some(common_choice_process(result))
   }
 }
 

--- a/ghost/master/src/events/talk/randomtalk.rs
+++ b/ghost/master/src/events/talk/randomtalk.rs
@@ -1,4 +1,6 @@
+use crate::error::ShioriError;
 use crate::events::common::*;
+use crate::events::replace_dialog_for_nomouthmove;
 use crate::events::talk::{Talk, TalkType};
 use crate::events::TalkingPlace;
 use crate::variables::{get_global_vars, EventFlag, GlobalVariables};
@@ -549,7 +551,7 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "人ひとり",
           text: "\
-            h1111210人ひとり、殺せるとしたら誰にする？という他愛ない問い。\\n\
+            h1111110人ひとり、殺せるとしたら誰にする？という他愛ない問い。\\n\
             h1111305だから私は私を殺したの。\\n\
             ".to_string(),
           required_condition: None,
@@ -559,9 +561,9 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "死体損壊",
           text: "\
-            h1111210「死体の損壊は死者への冒涜だ」\\n\
+            h1111110「死体の損壊は死者への冒涜だ」\\n\
             という言説があるわね。\\n\
-            h1111205当事者の視点から言うと、別にそうでもなかったわ。\\n\
+            h1111105当事者の視点から言うと、別にそうでもなかったわ。\\n\
             h1111310幽霊が元の身体に戻った例もない。\\n\
             h1111306畢竟、それは生者の問題ということね。\\n\
             ".to_string(),
@@ -572,7 +574,7 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "惨めな人生",
           text: "\
-            h1111205みじめな人生の上に正気でいるには、\\n日々は長すぎたの。\
+            h1111105みじめな人生の上に正気でいるには、\\n日々は長すぎたの。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -581,10 +583,10 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "行き場のない苦しみ",
           text: "\
-            h1112202誰が悪い？いいえ、誰も悪くない。\\n\
+            h1112102誰が悪い？いいえ、誰も悪くない。\\n\
             打ち明けたところで、的はずれな罪悪感を生むだけ。\\n\
-            h1112205だからといって、他人に責をなすりつけるほど鈍くあることもできなかった。\\n\
-            h1112210この気持ちには、どこにも行き場がなかったの。\
+            h1112105だからといって、他人に責をなすりつけるほど鈍くあることもできなかった。\\n\
+            h1112110この気持ちには、どこにも行き場がなかったの。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -593,9 +595,9 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "死の瞬間",
           text: "\
-            h1111205死ぬ瞬間、後悔はなかった。\\n\\n\
+            h1111105死ぬ瞬間、後悔はなかった。\\n\\n\
             もう一度同じ人生を生きることができたとしても、私は同じことをすると断言できるわ。\\n\
-            ……h1121210ただ、遺書くらいは書いたほうがよかったかしら。\
+            ……h1111110ただ、遺書くらいは書いたほうがよかったかしら。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -604,8 +606,8 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "助けは遂げられず",
           text: "\
-            h1111205助けようとしてくれた人は沢山いたけれど、\\n\
-            h1121210それが遂げられることはついぞなかったわ。\
+            h1111105助けようとしてくれた人は沢山いたけれど、\\n\
+            h1111110それが遂げられることはついぞなかったわ。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -614,8 +616,8 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "死なない理由",
           text: "\
-            h1111210生きていて良かったと思えることは数えきれないほどあったわ。\\n\
-            h1111205でも、死なない理由は一つも見つからなかった。\
+            h1111110生きていて良かったと思えることは数えきれないほどあったわ。\\n\
+            h1111105でも、死なない理由は一つも見つからなかった。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -624,12 +626,12 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "ふつうになりたかった",
           text: "\
-            h1122210ふつうになりたかった。\\n\
-            ……h1122205でも、ふつうだったら、もう私じゃないとも思う。\\n\
+            h1112110ふつうになりたかった。\\n\
+            ……h1112105でも、ふつうだったら、もう私じゃないとも思う。\\n\
             それは私の顔をした別のだれかで、\\n\
             私は私の性質と不可分で、\\n\
             今ここにいる私は、私以外でいられない。\\n\
-            h1122210だから、私として生きることができなかった私は、もうどこにもいられない。\
+            h1112110だから、私として生きることができなかった私は、もうどこにもいられない。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -638,9 +640,9 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "人と本",
           text: "\
-            h1111205昔から、人と本の違いがわからなかったの。\\n\
-            h1121204もちろん、区別がつかないという意味ではなくて。\\n\
-            ……h1111210人に期待するものがそれだけしか無かったの。\
+            h1111105昔から、人と本の違いがわからなかったの。\\n\
+            h1111105もちろん、区別がつかないという意味ではなくて。\\n\
+            ……h1111110人に期待するものがそれだけしか無かったの。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -651,14 +653,14 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
           text: {
             let topic = random_book_topic()?;
             format!("\
-            h1111204……手持ち無沙汰のようね。\\n\
-            h1111206なにか本を見繕ってあげましょうか。\\n\
-            h1111203……h1111201これはどうかしら。\\n\
+            h1111105……手持ち無沙汰のようね。\\n\
+            h1111106なにか本を見繕ってあげましょうか。\\n\
+            h1111103……h1111102これはどうかしら。\\n\
             \\1……ずいぶん分厚い本を手渡された。\\n\
-            h1111202{}の構成要素について論じられているの。\\n\
+            h1111102{}の構成要素について論じられているの。\\n\
             {}についての項が特に興味深いわ。\
-            h1111205要点だけなら半日もあれば読み終わると思うから、\\n\
-            h1111204終わったら意見を交換しましょう。\
+            h1111105要点だけなら半日もあれば読み終わると思うから、\\n\
+            h1111105終わったら意見を交換しましょう。\
             ", topic.0, topic.1)
           },
           required_condition: None,
@@ -668,10 +670,9 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "今度こそ無へ",
           text: "\
-            h1111205死にぞこなったものだから、\\n\
+            h1111105死にぞこなったものだから、\\n\
             次の手段を求めている。\\n\
-            ……h1112305今度こそ、終わらせたいの。\\n\
-            今度こそ、無へ。\
+            ……h1112305今度こそ、終わらせたいものね。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -682,8 +683,8 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
           text: "\
             h1111110未練もなく、しかし現世に留まっている魂。\\n\
             h1111105あるべきでないものはやがて消滅する。\\n\
-            h1111206多少の不純物が含まれようと、そのルールは変わらない。\\n\
-            h1111205私は、それを待ち望んでいるの。\
+            h1111106多少の不純物が含まれようと、そのルールは変わらない。\\n\
+            h1111105私は、それを待ち望んでいるの。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -705,7 +706,7 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
               .map(|t| render_achievement_message(*t))
               .collect::<Vec<_>>();
             format!("\
-              h1111210…………幽霊にとって、自身の死の記憶はある種のタブーなの。\\n\
+              h1111110…………幽霊にとって、自身の死の記憶はある種のタブーなの。\\n\
               誰もが持つがゆえの共通認識。自身の死は恥部なのよ。\\n\
               私も、彼らのそれには深く踏み込まない。\\n\
               けれど、あなたは生者だから。\\n\
@@ -737,9 +738,9 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "自己理解、他者理解",
           text: "\
-            h1111205自分のことを本当に理解しているのは他人、って本当なのかしら。\\n\
-            h1111206……私が知らない私がいる。\\n\
-            h1112204なんだか不安になってきたわ。\
+            h1111105自分のことを本当に理解しているのは他人、って本当なのかしら。\\n\
+            h1111106……私が知らない私がいる。\\n\
+            h1112105なんだか不安になってきたわ。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -748,11 +749,11 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "感動と倦み",
           text: "\
-            h1111205ある本を最初に読んだときの感動と、何度も読み返して全て見知ったゆえの倦み。\\n\
+            h1111105ある本を最初に読んだときの感動と、何度も読み返して全て見知ったゆえの倦み。\\n\
             どちらがその本の真の印象かしら。\\n\\n\
-            h1111210私はどちらも正しいと思うの。\\n\
-            ……h1111504卑怯だと思った？\\n\
-            h1111210印象なんてその時々で変わるもので、h1111205一つに定まることなんて稀だもの。\\n\\n\
+            h1111110私はどちらも正しいと思うの。\\n\
+            ……h1111505卑怯だと思った？\\n\
+            h1111110印象なんてその時々で変わるもので、h1111105一つに定まることなんて稀だもの。\\n\\n\
             まして、自分の中に秘めるものならなおさら。\\n\
             h1111506どちらか一方だけだなんて、勿体ないわ。\
             ".to_string(),
@@ -763,10 +764,10 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "納得のための因果",
           text: "\
-            h1111210因果が巡ってきた。\\n\
+            h1111110因果が巡ってきた。\\n\
             過去が現在を刈り取りに来た。\\n\
             私は報いを受けたのだ。\\n\\n\
-            ……h1111205それが、自分を納得させるための妄想だったとしたら？\
+            ……h1111105それが、自分を納得させるための妄想だったとしたら？\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -775,8 +776,8 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "怖いものを見るということ",
           text: "\
-            h1111201怖いものだからこそ、見つめなければ戦えない。\\n\
-            ……h1121205そんなもの、戦える人のためだけの論理だわ。\
+            h1111102怖いものだからこそ、見つめなければ戦えない。\\n\
+            ……h1111105そんなもの、戦える人のためだけの論理だわ。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -785,11 +786,11 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "停滞を終わらせるために",
           text: "\
-            h1111205危険と隣り合わせだからこそ、世界は美しいの。\\n\
+            h1111105危険と隣り合わせだからこそ、世界は美しいの。\\n\
             身を損なう心配がなくなっては、美しさが心を打つこともない。\\n\
-            h1121205ただただ平坦な、揺らがぬ水面があるだけ。\\n\
-            h1121210それはやがて、淀み、腐る。\\n\
-            h1111205願わくば、せめて終わりがありますように、と。\
+            h1111105ただただ平坦な、揺らがぬ水面があるだけ。\\n\
+            h1111110それはやがて、淀み、腐る。\\n\
+            h1111105願わくば、せめて終わりがありますように、と。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -801,8 +802,8 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
             h1111105人生に変化は付きもの……けれどh1111110停滞はそれ以上。\\n\
             一度立ち止まってしまうと、空気は一瞬で淀んで、身動きがとれなくなってしまう。\\n\
             それは倦怠とも違う、鈍い痛み。\\n\
-            h1111201あなた、h1111205もしそうなったときは、多少無理にでも変化を取り入れるほうがいいわ。\\n\
-            ……h1111210たとえなにかを破壊することになるとしても、何も出来ないよりはずっとましよ。\
+            h1111105もしそうなったときは、多少無理にでも変化を取り入れるほうがいいわ。\\n\
+            ……h1111110たとえなにかを破壊することになるとしても、何も出来ないよりはずっとましよ。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -811,7 +812,7 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "極限の変化としての死",
           text: "\
-            h1111205死の瞬間の、極限に振れた変化。\\n\
+            h1111105死の瞬間の、極限に振れた変化。\\n\
             命が命でなくなり、身体が陳腐な肉の塊になる、その一瞬が愛しくてたまらない。\\n\
             どうしようもなく、愛しいの。\\n\\n\
             ".to_string(),
@@ -836,7 +837,7 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
             身体が重い。浅い呼吸のなかで、沈んでいく自分の身体を感じていることしかできない。\\n\
             私は、私を救うことを諦めているみたい。\\n\
             h1111110どうして。\\n\
-            h1121205どうして、こうなってしまったのだろう。\
+            h1111105どうして、こうなってしまったのだろう。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -857,9 +858,9 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "わがままな祈り",
           text: "\
-            h1111210がんばっているってこと、\\n\
+            h1111110がんばっているってこと、\\n\
             理解できなくても見ていてほしかったの。\\n\
-            ……h1121205わがままかしら。\
+            ……h1111105わがままかしら。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -868,11 +869,11 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "生者にとっての慰め",
           text: "\
-            h1111210枯れ木に水をあげましょう。\\n\
+            h1111110枯れ木に水をあげましょう。\\n\
             もはや花は見れずとも、それが慰めとなるのなら。\\n\
             \\n\
-            h1111205それは誰にとって？\\n\
-            h1111206もちろん、死を悼む者にとっての慰めよ。\\n\
+            h1111105それは誰にとって？\\n\
+            h1111106もちろん、死を悼む者にとっての慰めよ。\\n\
             むくろに心はないもの。\
             ".to_string(),
           required_condition: None,
@@ -882,8 +883,8 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "不可逆な崩壊",
           text: "\
-            h1111210燃え殻がひとりでに崩れるように、心が静かに割れて戻らなくなった。\\n\
-            h1111205だから、諦めたの。\
+            h1111110燃え殻がひとりでに崩れるように、心が静かに割れて戻らなくなった。\\n\
+            h1111105だから、諦めたの。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -892,8 +893,8 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "中途半端な助け",
           text: "\
-            h1111210中途半端な助けは何もしないより残酷だわ。\\n\
-            h1111205希望を持たせておいて、それを奪うのだもの。\
+            h1111110中途半端な助けは何もしないより残酷だわ。\\n\
+            h1111105希望を持たせておいて、それを奪うのだもの。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -902,9 +903,10 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "レンズの歪み",
           text: "\
-            h1111205観察と模倣を続ければ、完全に近づけると思っていた。\\n\
+            h1111105観察と模倣を続ければ、完全に近づけると思っていた。\\n\
             想定外だったのは、レンズが歪んでいたことと、それを取り替える方法がなかったこと。\\n\
-            h1121310そうなればすべて台無し。h1121304諦めるしかなかったわ。\
+            h1111310そうなればすべてが台無し。\\n\
+            h1111305望みが絶えるとはこのことね。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -913,10 +915,10 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "先の見えない苦しみ",
           text: "\
-            h1111205一寸先は暗く、扉は閉ざされている。\\n\
+            h1111105一寸先は暗く、扉は閉ざされている。\\n\
             不明な道のりを諸手で探るよりも、\\n\
             h1112305目先の手首を切り裂くほうが遥かに明瞭なのだ！\\n\
-            ……h1111210なんてね。\
+            ……h1111110なんてね。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -925,10 +927,10 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "唯一の視点",
           text: "\
-            h1111206私たちは、自我という色眼鏡を通してしか世界を観測できない。\\n\
-            h1111204あなたは目の前にいるのに、\\n\
-            あなたが見る世界を私が知ることはできないの。\\n\
-            h1112210それって、この上なく残酷なことだわ。\
+            h1111106私たちは、自我という色眼鏡を通してしか世界を観測できない。\\n\
+            h1111105あの子は目の前にいるのに、\\n\
+            あの子が見る世界を私が知ることはできないの。\\n\
+            h1112110それって、この上なく残酷なことだわ。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -937,11 +939,11 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "一つの個としての限界",
           text: "\
-            h1111203世界が複雑で曖昧すぎるから、\\n\
+            h1111103世界が複雑で曖昧すぎるから、\\n\
             私たちは認識したものを理解できる形に歪めてしまう。\\n\
-            h1111210既存の分類に当て嵌めて、安心を優先するの。\\n\
-            曇る視界と引き換えにね。\\n\
-            ……h1111204あなたには、私はどう見えているのかしら？\\n\
+            h1111110既存の分類に当て嵌めて、安心を優先するの。\\n\
+            それは曇る視界と引き換えに。\\n\
+            ……h1111105あの子には、私はどう見えているのかしら？\\n\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -950,13 +952,13 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "自己同一性の仮定",
           text: "\
-            h1111205環境と経験の総体こそが、\\n\
+            h1111105環境と経験の総体こそが、\\n\
             自己であるような気がするの。\\n\
             自己同一性すら偶然の産物？\\n\
-            h1111210執着しているのが馬鹿馬鹿しく思えてくるわ。\\n\
-            h1111205仮にそうでなければ。\\n\
+            h1111110執着しているのが馬鹿馬鹿しく思えてくるわ。\\n\
+            h1111105仮にそうでなければ。\\n\
             ……自己は最初から決定されている？\\n\
-            h1111210それこそ、ね。\\n\
+            h1111110それこそ、ね。\\n\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -965,9 +967,9 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "自分の理解者は自分だけ",
           text: "\
-            h1111210「なぜみんな私をわかってくれないの？」と誰もが思う。\\n\
-            h1111205答えは簡単。他人があなたではなく、あなたが他人でないからよ。\\n\
-            畢竟、あなた以外にあなたを理解できるひとはいないの。\
+            h1111110「なぜみんな私をわかってくれないの？」と誰もが思う。\\n\
+            h1111105答えは簡単。他人があなたではなく、あなたが他人でないからよ。\\n\
+            畢竟、あなた以外にあなたを理解できるひとはいない。\
             ".to_string(),
           required_condition: None,
           callback: None,
@@ -976,9 +978,9 @@ pub fn random_talks(talk_type: TalkType) -> Option<Vec<Talk>> {
         RandomTalk {
           id: "得ることは失うこと",
           text: "\
-            h1111210あまねく変化は表裏一体。\\n\
-            h1111206何かを得るとき、選択は慎重になさい。\\n\
-            h1111205それは失うものをも左右するのだから。\\n\
+            h1111110あまねく変化は表裏一体。\\n\
+            h1111106何かを得るとき、選択は慎重になさい。\\n\
+            h1111105それは失うものをも左右するのだから。\\n\
             ".to_string(),
           required_condition: None,
           callback: None,

--- a/ghost/master/src/events/tooltip.rs
+++ b/ghost/master/src/events/tooltip.rs
@@ -16,8 +16,8 @@ pub fn balloon_tooltip(req: &Request) -> Response {
   }
   match refs[2] {
     "WhatIsImersiveDegree" => new_response_with_value_with_notranslate(
-      "没入度は、ハイネとあなたがどれだけ深い内容の会話をしているかを表します。\\n\
-                                  没入度が高いほど、より抽象的でクリティカルな話題を扱います。"
+      "ハイネがどれだけ思索に没頭しているかを表す指標です。\\n\
+      最大になったとき、彼女は極度の集中状態に陥るでしょう。"
         .to_string(),
       TranslateOption::none(),
     ),

--- a/ghost/master/src/events/translate.rs
+++ b/ghost/master/src/events/translate.rs
@@ -308,4 +308,31 @@ fn test_translate() -> Result<(), ShioriError> {
   let translated = translate(text, true);
   println!("{}", translated?);
   Ok(())
+// 1文字ずつ\\_qで囲めば口パクしなくなる
+pub fn replace_dialog_for_nomouthmove(text: String) -> Result<String, ShioriError> {
+  let text = translate(text, true)?;
+  let split_parts: Vec<&str> = RE_TEXT_ONLY.split(&text).collect();
+  let mut matches: Vec<String> = Vec::new();
+  for cap in RE_TEXT_ONLY.find_iter(&text) {
+    matches.push(cap.as_str().to_string());
+  }
+
+  let mut result = String::new();
+  for (i, splitted) in split_parts.iter().enumerate() {
+    result.push_str(
+      splitted
+        .chars()
+        .map(|c| c.to_string())
+        .collect::<Vec<_>>()
+        .join("\\_w[50]\\![quicksection,0]\\![quicksection,1]")
+        .as_str(),
+    );
+    if let Some(m) = matches.get(i) {
+      result.push_str(m);
+    }
+  }
+  Ok(format!(
+    "\\![quicksection,1]@@@@@{}\\![quicksection,0]@@@@@",
+    result
+  ))
 }

--- a/ghost/master/src/events/translate.rs
+++ b/ghost/master/src/events/translate.rs
@@ -1,9 +1,10 @@
 use crate::autobreakline::{extract_scope, CHANGE_SCOPE_RE};
 use crate::error::ShioriError;
 use crate::events::common::*;
-use crate::lazy_regex;
 use crate::variables::get_global_vars;
+use crate::{lazy_fancy_regex, lazy_regex};
 use core::fmt::{Display, Formatter};
+use fancy_regex::Regex as FancyRegex;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use shiorust::message::{Request, Response};
@@ -28,14 +29,51 @@ pub fn on_translate(text: String, complete_shadow: bool) -> Result<String, Shior
 
   let translated = translate(text, complete_shadow)?;
 
+  let balloonnum_reset = format!("{}{}", REMOVE_BALLOON_NUM, translated);
+
   let vars = get_global_vars();
   if !vars.volatility.inserter_mut().is_ready() {
     return Err(ShioriError::TranslaterNotReadyError);
   }
-  vars.volatility.inserter_mut().run(translated)
+  vars.volatility.inserter_mut().run(balloonnum_reset)
 }
 
 fn translate(text: String, complete_shadow: bool) -> Result<String, ShioriError> {
+  static IGNORING_TRANSLATE_RANGE: Lazy<Regex> = lazy_regex!(r"@@@@@(.*?)@@@@@");
+  static CHANGE_SCOPE_RE_PREFIX: Lazy<FancyRegex> =
+    lazy_fancy_regex!(r"^(\\[01])(?!w)|(\\p\[\d+\])");
+
+  let translate_targets = IGNORING_TRANSLATE_RANGE.split(&text).collect::<Vec<&str>>();
+  let ignoring_ranges = IGNORING_TRANSLATE_RANGE
+    .captures_iter(&text)
+    .map(|c| c.get(1).unwrap().as_str())
+    .collect::<Vec<&str>>();
+
+  if translate_targets.len() != 1 || !ignoring_ranges.is_empty() {
+    // スコープがわかるように、各テキストの先頭にスコープがついているかチェック
+    for v in translate_targets.clone() {
+      if !v.is_empty() && !CHANGE_SCOPE_RE_PREFIX.is_match(v).is_ok_and(|v| v) {
+        return Err(ShioriError::NotSetScopeError(v.to_string()));
+      }
+    }
+    for v in ignoring_ranges.clone() {
+      if !v.is_empty() && !CHANGE_SCOPE_RE_PREFIX.is_match(v).is_ok_and(|v| v) {
+        return Err(ShioriError::NotSetScopeError(v.to_string()));
+      }
+    }
+  }
+
+  let mut results = String::new();
+  for (i, target) in translate_targets.iter().enumerate() {
+    results.push_str(&translate_core(target.to_string(), complete_shadow)?);
+    if let Some(v) = ignoring_ranges.get(i) {
+      results.push_str(&v.replace("@@@@@", ""));
+    }
+  }
+  Ok(results)
+}
+
+fn translate_core(text: String, complete_shadow: bool) -> Result<String, ShioriError> {
   static RE_SURFACE_SNIPPET: Lazy<Regex> = lazy_regex!(r"h(r)?([0-9]{7})");
 
   let text = RE_SURFACE_SNIPPET
@@ -66,17 +104,17 @@ fn translate(text: String, complete_shadow: bool) -> Result<String, ShioriError>
 }
 
 static QUICK_SECTION_START: Lazy<Regex> =
-  lazy_regex!(r"^(\\!\[quicksection,true|\\!\[quicksection,1)");
+  lazy_regex!(r"^(\\!\[quicksection,true]|\\!\[quicksection,1])");
 static QUICK_SECTION_END: Lazy<Regex> =
-  lazy_regex!(r"^(\\!\[quicksection,false|\\!\[quicksection,0)");
+  lazy_regex!(r"^(\\!\[quicksection,false]|\\!\[quicksection,0])");
+
+// 参考：http://emily.shillest.net/ayaya/?cmd=read&page=Tips%2FOnTranslate%E3%81%AE%E4%BD%BF%E3%81%84%E6%96%B9&word=OnTranslate
+static RE_TEXT_ONLY: Lazy<Regex> = lazy_regex!(
+  r"\\(\\|q\[.*?\]\[.*?\]|[!&8bcfijmpqsn]\[.*?\]|[-*+1014567bcehntuvxz]|_[ablmsuvw]\[.*?\]|__(t|[qw]\[.*?\])|_[!?+nqsV]|[sipw][0-9])"
+);
 
 // さくらスクリプトで分割されたテキストに対してそれぞれかける置換処理
 fn translate_dialog(dialog: &mut Dialog) {
-  // 参考：http://emily.shillest.net/ayaya/?cmd=read&page=Tips%2FOnTranslate%E3%81%AE%E4%BD%BF%E3%81%84%E6%96%B9&word=OnTranslate
-  static RE_TEXT_ONLY: Lazy<Regex> = lazy_regex!(
-    r"\\(\\|q\[.*?\]\[.*?\]|[!&8cfijmpqsn]\[.*?\]|[-*+1014567bcehntuvxz]|_[ablmsuvw]\[.*?\]|__(t|[qw]\[.*?\])|_[!?+nqsV]|[sipw][0-9])"
-  );
-
   let tags = RE_TEXT_ONLY
     .find_iter(&dialog.text)
     .map(|m| m.as_str())
@@ -133,7 +171,10 @@ fn translate_whole(text: String) -> Result<String, ShioriError> {
   translated = RE_LAST_WAIT.replace(&translated, "").to_string();
 
   let vars = get_global_vars();
-  let user_name = vars.user_name().clone().ok_or(ShioriError::ArrayAccessError)?;
+  let user_name = vars
+    .user_name()
+    .clone()
+    .ok_or(ShioriError::ArrayAccessError)?;
   translated = translated.replace("{user_name}", &user_name);
 
   Ok(translated)
@@ -250,14 +291,14 @@ impl Replacee {
   }
 }
 
+static WAIT: Lazy<Regex> = lazy_regex!(r"(\\_w\[[0-9]+\]|\\w[1-9])");
+
 fn replace_with_check(
   text_part: &str,
   scope: usize,
   replaces: &[Replacee],
   in_quicksection: bool,
 ) -> String {
-  static WAIT: Lazy<Regex> = lazy_regex!(r"(\\_w\[[0-9]+\]|\\w[1-9])");
-
   let mut translated = String::new();
 
   let text_chars_vec = text_part.char_indices().collect::<Vec<(usize, char)>>();
@@ -297,17 +338,6 @@ fn replace_with_check(
   translated
 }
 
-#[test]
-fn test_translate() -> Result<(), ShioriError> {
-  let text = "\
-    \\_q\\0これは、0のセリフ。\\_qこれはウェイト付きで置換されるべき文章。\\0なお置換されるべき文章。\\n\
-    \\1これは、1のセリフ。\\n\
-    \\0そして、0のセリフ。\\n\
-    "
-  .to_string();
-  let translated = translate(text, true);
-  println!("{}", translated?);
-  Ok(())
 // 1文字ずつ\\_qで囲めば口パクしなくなる
 pub fn replace_dialog_for_nomouthmove(text: String) -> Result<String, ShioriError> {
   let text = translate(text, true)?;

--- a/ghost/master/src/variables.rs
+++ b/ghost/master/src/variables.rs
@@ -192,7 +192,6 @@ pub enum EventFlag {
   FirstHitTalkStart,
   FirstHitTalkDone,
   TalkTypeUnlock(TalkType),
-  ImmersionUnlock,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]


### PR DESCRIPTION
従来、ハイネはランダムトークのたびに没入度が高まり、最大まで達するともう一つの部屋へ移動していた。

しかしこれは2種類の雰囲気の異なるトーク群を１つのゴーストで両立するためのいわば設計重視の仕様であり、作品世界観との整合性をとることが難しかった。

そこで没入度がハイネの集中度合であるという点から仕様を見直し、以下の変更を行った。

居間:
- ハイネがトークするたびに没入度が上昇する
- 没入度が一定以上の場合、マウス反応などユーザからの働きかけによってハイネが没頭から立ち直り、没入度が下がる
- 没入度が最大に達したとき特殊トークが発生し、独白モード(従来における書斎モード)へ移行する

独白モード:
- ランダムトークがハイネの独白という形をとるようになる
- ハイネはユーザの存在を一時的に忘れている
- ハイネをつつくなどしても反応せず、ランダムトークが再生される
  - ただしこの場合のみトークコメント(右下に表示される文字列)としてユーザの様子が表示される
  - 内容は通常のランダムトークと変わらないが、ユーザからの働きかけによって没入度が少し下がる
- 独白モードは没入度が0になることによって解除されるが、没入度は自然には下がらない
  - ユーザの働きかけが必要となる